### PR TITLE
Fix PixelFormat's Stride calculation to account for framebuffer inconsistency.

### DIFF
--- a/bgr565.go
+++ b/bgr565.go
@@ -43,7 +43,7 @@ func (i *BGR565) SetRGB(x, y int, c RGBColor) {
 
 	n := i.PixOffset(x, y)
 	pix := i.Pix[n:]
-	clr := (uint16(c.G)<<11) | (uint16(c.G)<<5) | uint16(c.R)
+	clr := (uint16(c.G) << 11) | (uint16(c.G) << 5) | uint16(c.R)
 
 	pix[0] = uint8(clr)
 	pix[1] = uint8(clr >> 8)

--- a/canvas.go
+++ b/canvas.go
@@ -451,6 +451,7 @@ func (c *Canvas) CurrentMode() (*DisplayMode, error) {
 	dm.VMode = int(v.vmode)
 
 	var pf PixelFormat
+	pf.Depth = uint8(v.bits_per_pixel)
 	pf.RedBits = uint8(v.red.length)
 	pf.RedShift = uint8(v.red.offset)
 	pf.GreenBits = uint8(v.green.length)

--- a/pixelformat.go
+++ b/pixelformat.go
@@ -55,6 +55,7 @@ const (
 //    a := (pixel >> alpha_shift) & alpha_mask
 //
 type PixelFormat struct {
+	Depth      uint8 // Total bit count for each pixel.
 	RedBits    uint8 // Bit count for the red channel.
 	RedShift   uint8 // Shift offset for the red channel.
 	GreenBits  uint8 // Bit count for the green channel.
@@ -67,7 +68,7 @@ type PixelFormat struct {
 
 // Stride returns the width, in bytes, for a single pixel.
 func (p PixelFormat) Stride() int {
-	return int(math.Ceil(float64(p.RedBits+p.GreenBits+p.BlueBits+p.AlphaBits) / 8))
+	return int(math.Ceil(float64(p.Depth) / 8))
 }
 
 // Type returns an integer constant from the PF_XXX list, which


### PR DESCRIPTION
On my laptop running vanilla Debian Sid, my framebuffer uses 32 bits per pixel,
but the 4th byte isn't used for alpha. The alpha channel's length and offset
are both 0.

That throws off the PixelFormat.Stride function, making it think that the
framebuffer format is only 24bpp. So I changed PixelFormat to have an
addition Depth field that gets set from fb_var_screeninfo.bits_per_pixel and
all's well now.